### PR TITLE
fixing the poller so it polls things

### DIFF
--- a/hourglass.ini.sample
+++ b/hourglass.ini.sample
@@ -11,22 +11,21 @@ cache = sqlite:////tmp/hourglass-cache.db
 uchiwa_url = http://url.to.uchiwa.com/
 enabled_sensu_nodes = region1,region2
 enabled_dashboards = admin,support
+poll_interval = 30
 
 [admin]
-checkname = !datastore-connection,!mysqld-not-running
+check_name = !datastore-connection,!mysqld-not-running
 
 [support]
 datacenter = !region1
-checkname = mysqld-not-running,datastore-connection,guest-queues
+check_name = mysqld-not-running,datastore-connection,guest-queues
 
 [region1]
-name = test1
 host = localhost
 port = 4567
 timeout = 10
 
 [region2]
-name = test2
 host = localhost
 port = 4568
 timeout = 10

--- a/hourglass/__init__.py
+++ b/hourglass/__init__.py
@@ -1,7 +1,7 @@
 from flask import Flask
 from flask.ext.iniconfig import INIConfig
-from hourglass.models.poller import Poller
 from hourglass.models.backends import db
+
 
 def create_app(config):
     global app

--- a/hourglass/models/poller.py
+++ b/hourglass/models/poller.py
@@ -1,80 +1,55 @@
 import asyncio
 import aiohttp
-from hourglass.models.backends.sensu.cache import Check, Client, Event, Stash
+from hourglass.models.backends.sensu.cache import Check, Client, Event, Stash, Result
 from hourglass.models.backends import db
 
 
 class Poller(object):
     def __init__(self, app):
+        self.sensu_models = [Check, Client, Event, Stash, Result]
         self.app = app
         self.db = db
-        self.httpsession = aiohttp.ClientSession()
         self.sensus = self.app.config['sensu_nodes']
         self.interval = self.app.config['hourglass'].get('poll_interval', 10)
         self.loop = asyncio.get_event_loop()
+        self.httpsession = aiohttp.ClientSession(loop=self.loop)
 
     @asyncio.coroutine
-    def query_sensu(self, sensu, uri):
-        url = "http://%s:%s/%s" % (sensu['host'], sensu['port'], uri)
-        with aiohttp.Timeout(sensu['timeout']):
-            response = yield from self.httpsession.get(url)
-        return (yield from response.json())
+    def query_sensu(self, details, uri):
+        timeout = int(details.get('timeout', 5))
+        url = "http://%s:%s/%s" % (details['host'], details['port'], uri)
+        out_dict = {}
+        try:
+            with aiohttp.Timeout(timeout):
+                response = yield from self.httpsession.get(url)
+                out_dict = yield from response.json()
+                response.release()
+        except:
+            self.app.logger.debug("Reached timeout on request to %s" % url)
+        return (out_dict)
 
     @asyncio.coroutine
-    def update_sensu_checks(self, sensu):
-        self.app.logger.debug("updating checks " + sensu['name'])
-        checks = yield from self.query_sensu(sensu, 'checks')
-        checkobjects = []
+    def update_sensu_object(self, name, details, model):
+        self.app.logger.debug("Updating %s cache for %s" % (
+            model.__tablename__, name))
+        checks = yield from self.query_sensu(details, model.__tablename__)
+        init_objects = []
         for check in checks:
-            checkobjects.append(Check(sensu['name'], check))
-        self.app.logger.debug("updated checks " + sensu['name'])
-        return checkobjects
+            init_objects.append(model(name, check))
+        self.app.logger.debug("Updated %s cache for %s" % (
+            model.__tablename__, name))
+        return init_objects
 
-    @asyncio.coroutine
-    def update_sensu_clients(self, sensu):
-        self.app.logger.debug("updating clients " + sensu['name'])
-        clients = yield from self.query_sensu(sensu, 'clients')
-        clientobjects = []
-        for client in clients:
-            clientobjects.append(Client(sensu['name'], client))
-        self.app.logger.debug("updated clients " + sensu['name'])
-        return clientobjects
-
-    @asyncio.coroutine
-    def update_sensu_events(self, sensu):
-        self.app.logger.debug("updating events " + sensu['name'])
-        events = yield from self.query_sensu(sensu, 'events')
-        eventobjects = []
-        for event in events:
-            eventobjects.append(Event(sensu['name'], event))
-        self.app.logger.debug("updated events " + sensu['name'])
-        return eventobjects
-
-    @asyncio.coroutine
-    def update_sensu_stashes(self, sensu):
-        self.app.logger.debug("updating stashes " + sensu['name'])
-        stashes = yield from self.query_sensu(sensu, 'stashes')
-        stashobjects = []
-        for stash in stashes:
-            stashobjects.append(Stash(sensu['name'], stash))
-        self.app.logger.debug("updated stashes " + sensu['name'])
-        return stashobjects
-
-    def main(self):
+    def update_cache(self):
         self.app.logger.debug('Updating Cache')
-        tasks = []
-        for sensu in self.sensus:
-            tasks.append(asyncio.ensure_future(self.update_sensu_checks(self.sensus[sensu])))
-            tasks.append(asyncio.ensure_future(self.update_sensu_clients(self.sensus[sensu])))
-            tasks.append(asyncio.ensure_future(self.update_sensu_events(self.sensus[sensu])))
-            tasks.append(asyncio.ensure_future(self.update_sensu_stashes(self.sensus[sensu])))
         with self.app.app_context():
+            tasks = []
+            for name, details in self.sensus.items():
+                for model in self.sensu_models:
+                    self.app.logger.debug('Purging cache %s for %s' % (model.__tablename__, name))
+                    model.query.filter(model.datacenter == name).delete()
+                    tasks.append(asyncio.async(self.update_sensu_object(name, details, model)))
             self.loop.run_until_complete(asyncio.wait(tasks))
-            for sensu in self.sensus:
-                Check.query.filter(Check.datacenter==sensu).delete()
-                Client.query.filter(Client.datacenter==sensu).delete()
-                Event.query.filter(Event.datacenter==sensu).delete()
-                Stash.query.filter(Stash.datacenter==sensu).delete()
             for task in tasks:
                 self.db.session.bulk_save_objects(task.result())
             self.db.session.commit()

--- a/hourglass/shell.py
+++ b/hourglass/shell.py
@@ -1,14 +1,24 @@
 import os
-from flask.ext.script import Manager, Shell
-from hourglass.models.backends.sensu.cache import Client, Check, Event, Stash, db
+from flask.ext.script import Command, Manager, Shell
+from hourglass.models.backends.sensu.cache import Client, Check, Event, Result, Stash, db
+from hourglass.models.poller import Poller
 from . import create_app
 
 BASEDIR = os.path.abspath(os.path.curdir)
 
 
 def make_shell_context():
-    return dict(create_app=create_app, db=db, Check=Check, Client=Client,
-                Event=Event, Stash=Stash)
+    return dict(create_app=create_app, db=db, Poller=Poller, Check=Check,
+                Client=Client, Event=Event, Stash=Stash, Result=Result)
+
+
+class init_db(Command):
+    "Initializes the database with default values (DATA DESTRUCTIVE!)"
+
+    def run(self):
+        db.drop_all()
+        db.create_all()
+        print("Done!")
 
 
 def run_hourglass(cwd=BASEDIR):
@@ -16,4 +26,5 @@ def run_hourglass(cwd=BASEDIR):
     manager.add_option('-c', '--config', dest='config', required=False,
                        default='%s/hourglass.ini' % cwd)
     manager.add_command('shell', Shell(make_context=make_shell_context))
+    manager.add_command("initdb", init_db())
     manager.run()

--- a/hourglass/views/api/views.py
+++ b/hourglass/views/api/views.py
@@ -49,7 +49,7 @@ def ping():
 def list_datacenters():
     dashboard = request.args.get('dashboard')
     config = current_app.config
-    datacenters = [x for x in config['sensu_nodes'].keys()]
+    datacenters = [x for x in config['sensu_nodes']]
     if dashboard:
         datacenters_string = config['dashboards'][dashboard].get('datacenter')
         include, exclude = parse_include_excludes(datacenters_string)

--- a/wsgi.py
+++ b/wsgi.py
@@ -2,12 +2,13 @@ from hourglass import create_app
 from hourglass.models.poller import Poller
 from uwsgidecorators import timer
 
+
 app = create_app('./hourglass.ini')
 poller = Poller(app)
-poller.main()
+poller.update_cache()
 poll_interval = app.config['hourglass'].get('poll_interval', 10)
 
 
 @timer(poll_interval)
 def run_poller(signum):
-    poller.main()
+    poller.update_cache()


### PR DESCRIPTION
Poller currently works best when you only run with one worker process in uwsgi. Pretty sure it's because it kicks off multiple timers based on the worker count..... might need to look at that again in the future.

This update should make it work with python 3.4.3 without issue.

Oh, changed the name of the variable in the hourglass.ini from checkname to check_name to match the rest of the variables names.

Signed-off-by: M. David Bennett mdavidbennett@syntheticworks.com
