### PR TITLE
Update event details page to work with 'OK' results

### DIFF
--- a/hourglass/views/api/views.py
+++ b/hourglass/views/api/views.py
@@ -147,13 +147,26 @@ def client_events_check(zone, client, check):
                (check, Event.check_name))
     filters_list = get_filters_list(filters)
     events = Event.query.filter(*filters_list).all_extra_as_dict()
-    return jsonify({'events': events, 'timestamp': time()})
+    response = jsonify({'events': events, 'timestamp': time()})
+    if not events:
+        response.status_code = 404
+    return response
 
 
 @api.route('/clients/<zone>/<client>/results')
 def client_results(zone, client):
     filters = ((zone, Result.zone_name),
                (client, Result.client_name))
+    filters_list = get_filters_list(filters)
+    results = Result.query.filter(*filters_list).all_extra_as_dict()
+    return jsonify({'results': results, 'timestamp': time()})
+
+
+@api.route('/clients/<zone>/<client>/results/<check>')
+def client_results_check(zone, client, check):
+    filters = ((zone, Result.zone_name),
+               (client, Result.client_name),
+               (check, Result.check_name))
     filters_list = get_filters_list(filters)
     results = Result.query.filter(*filters_list).all_extra_as_dict()
     return jsonify({'results': results, 'timestamp': time()})

--- a/hourglass/views/main/static/js/hourglass/client_event_details.js
+++ b/hourglass/views/main/static/js/hourglass/client_event_details.js
@@ -1,9 +1,19 @@
 $(document).ready(function() {
     $('#clientdetails').html(function() {
-        $.getJSON('/api/clients/'+ZONE+'/'+CLIENT+'/events/'+CHECK, function(data) {
+        var jqxhr = $.getJSON('/api/clients/'+ZONE+'/'+CLIENT+'/events/'+CHECK, function(data) {
             event = data['events'][0];
             $('#clientdetails').html('<h4>'+event['client']['name']+'</h4><pre>'+JSON.stringify(event['client'],null,2)+'</pre>');
             $('#eventdetails').html('<h4>'+event['check']['name']+'</h4><pre>'+JSON.stringify(event['check'],null,2)+'</pre>');
+        })
+        .fail(function() {
+            $.getJSON('/api/clients/'+ZONE+'/'+CLIENT, function(data) {
+                client = data['clients'][0];
+                $('#clientdetails').html('<h4>'+client['name']+'</h4><pre>'+JSON.stringify(client,null,2)+'</pre>');
+            })
+            $.getJSON('/api/clients/'+ZONE+'/'+CLIENT+'/results/'+CHECK, function(data) {
+                event = data['results'][0];
+                $('#eventdetails').html('<h4>'+event['check']['name']+'</h4><pre>'+JSON.stringify(event['check'],null,2)+'</pre>');
+            })
         })
     })
 })


### PR DESCRIPTION
Signed-off-by: Chris Jowett chris.jowett@rackspace.com

@testeddoughnut note the change to the API views.py to support returning a 404 if there are no events found.  We should probably do this for the other API calls as well.
